### PR TITLE
Makefiles fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(aes-cli LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(Catch2 3 REQUIRED)
 find_package(

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-test:
+test: cmakebuild runtest
+
+cmakebuild:
+	cmake -H. -Bbuild
 	cmake --build build
-	./build/test_io
-	./build/test_padding
+
+runtest:
+	./build/test_io -d yes
+	./build/test_crypto -d yes
+	./build/test_ciphermode -d yes


### PR DESCRIPTION
- Added the `CMAKE_EXPORT_COMPILE_COMMANDS` in CMake
- Fixed Makefile rules

NOTE that I checked this file out from my current working branch, so when you run
`make test` one of the test binary will not be found.
